### PR TITLE
Remove warning when standard error is saved to a different file than standard out.

### DIFF
--- a/R/run.R
+++ b/R/run.R
@@ -44,7 +44,7 @@ run_r <- function(bin, args, libpath, repos, stdout, stderr, echo, show,
   ## then we need to append here
   if (!is.null(stderr)) {
     append <- ! is.null(stdout) &&
-      normalizePath(stdout) == normalizePath(stderr)
+      normalizePath(stdout) == normalizePath(stderr, mustWork = FALSE)
     cat(out$stderr, file = stderr, append = append)
   }
 

--- a/tests/testthat/test-eval.R
+++ b/tests/testthat/test-eval.R
@@ -24,6 +24,18 @@ test_that("standard error", {
   expect_equal(readLines(tmp), "hello")
 })
 
+test_that("standard output and standard error", {
+  tmp_out <- tempfile("stdout-")
+  tmp_err <- tempfile("stderr-")
+  on.exit(unlink(c(tmp_out, tmp_err)), add = TRUE)
+  expect_silent(
+    r(function() { cat("hello world!\n"); message("hello again!") },
+      stdout = tmp_out, stderr = tmp_err)
+  )
+  expect_equal(readLines(tmp_out), "hello world!")
+  expect_equal(readLines(tmp_err), "hello again!")
+})
+
 test_that("cmdargs argument", {
   o1 <- tempfile()
   o2 <- tempfile()


### PR DESCRIPTION
A warning is produced when standard out and standard error are saved to two separate files. Using the example code from the [README](https://github.com/r-pkgs/callr/blob/c02300a8afc530f41c63c29cba66528e201b9dac/README.md):

```
library("callr")
x <- r(function() { print("hello world!"); message("hello again!") },
       stdout = "/tmp/out", stderr = "/tmp/err"
)
#> Warning message:
#> In normalizePath(stderr) : path[1]="/tmp/err": No such file or directory
```

The warning was introduced in commit 3007ba2 in response to Issue #12.